### PR TITLE
Permit passing arbitrary structures in the product description data

### DIFF
--- a/lib/Amazon/MWS/XML/Order.pm
+++ b/lib/Amazon/MWS/XML/Order.pm
@@ -498,5 +498,15 @@ sub shipping_tax {
     return $out;
 }
 
+sub is_prime {
+    my $self = shift;
+    my $is_prime = $self->order->{IsPrime};
+    if ($is_prime and $is_prime =~ m/true/i) {
+        return 1;
+    }
+    else {
+        return 0;
+    }
+}
 
 1;

--- a/lib/Amazon/MWS/XML/Product.pm
+++ b/lib/Amazon/MWS/XML/Product.pm
@@ -163,6 +163,11 @@ Maker of the product (max 50 chars)
 
 Part number manufacturer.
 
+=item merchant_shipping_group_name
+
+The shipping template name. Please note that you need a recent XSD for
+this.
+
 =item description_data({ OtherItemAttributes => 'XYZ', ... })
 
 Arbitrary structure in the product feed can be passed here. This is

--- a/lib/Amazon/MWS/XML/Product.pm
+++ b/lib/Amazon/MWS/XML/Product.pm
@@ -163,6 +163,12 @@ Maker of the product (max 50 chars)
 
 Part number manufacturer.
 
+=item description_data({ MerchantShippingGroupName => 'XYZ', ... })
+
+Arbitrary structure in the product feed can be passed here. This is
+for maximum flexibility but keep in mind that the XSD you are using
+must have the corresponding definition.
+
 =back
 
 =cut
@@ -296,6 +302,10 @@ has ship_in_days => (is => 'ro',
                      isa => Int,
                      default => sub { '2' });
 
+has description_data => (is => 'ro',
+                         isa => HashRef,
+                        );
+
 has price => (is => 'ro',
               required => 1,
               isa => \&_validate_price);
@@ -428,6 +438,9 @@ sub as_product_hash {
     # and totally
     # $data->{NumberOfItems} = 1
 
+    if (my $desc_data = $self->description_data) {
+        $data->{DescriptionData} = { %$desc_data };
+    }
     if (my $title = $self->title) {
         $data->{DescriptionData}->{Title} = $title;
     }

--- a/lib/Amazon/MWS/XML/Product.pm
+++ b/lib/Amazon/MWS/XML/Product.pm
@@ -163,7 +163,7 @@ Maker of the product (max 50 chars)
 
 Part number manufacturer.
 
-=item description_data({ MerchantShippingGroupName => 'XYZ', ... })
+=item description_data({ OtherItemAttributes => 'XYZ', ... })
 
 Arbitrary structure in the product feed can be passed here. This is
 for maximum flexibility but keep in mind that the XSD you are using
@@ -305,6 +305,9 @@ has ship_in_days => (is => 'ro',
 has description_data => (is => 'ro',
                          isa => HashRef,
                         );
+
+has merchant_shipping_group_name => (is => 'ro',
+                                     isa => Str);
 
 has price => (is => 'ro',
               required => 1,
@@ -494,6 +497,9 @@ sub as_product_hash {
                                                      unitOfMeasure => $unit,
                                                      _ => $ship_weight,
                                                     };
+    }
+    if (my $merchant_shipping_group_name = $self->merchant_shipping_group_name) {
+        $data->{DescriptionData}->{MerchantShippingGroupName} = $merchant_shipping_group_name;
     }
 
     if (my $product_data = $self->product_data) {

--- a/t/feeds.t
+++ b/t/feeds.t
@@ -44,6 +44,8 @@ foreach my $product ({
                       shipping_weight => '5',
                       shipping_weight_unit => 'GR',
                       package_weight => 290,
+                      merchant_shipping_group_name => 'XYZ',
+                      description_data => { OtherItemAttributes => 'WXY' },
                      },
                      {
                       sku => '3333',
@@ -109,7 +111,9 @@ my $exp_product_feed = <<'XML';
         <SearchTerms>c</SearchTerms>
         <SearchTerms>d</SearchTerms>
         <SearchTerms>e</SearchTerms>
+        <OtherItemAttributes>WXY</OtherItemAttributes>
         <RecommendedBrowseNode>111111</RecommendedBrowseNode>
+        <MerchantShippingGroupName>XYZ</MerchantShippingGroupName>
       </DescriptionData>
       <ProductData>
         <CE>

--- a/t/orders.t
+++ b/t/orders.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 36;
+use Test::More tests => 38;
 
 use Amazon::MWS::XML::Order;
 use Amazon::MWS::XML::Address;
@@ -20,6 +20,9 @@ my $order_data = {
                   'ShippedByAmazonTFM' => 'false',
                   'SalesChannel' => 'Amazon.de',
                   'LastUpdateDate' => '2014-10-27T09:38:56Z',
+                  IsBusinessOrder => "true",
+                  IsPremiumOrder => "true",
+                  IsPrime => "true",
                   'NumberOfItemsShipped' => '2',
                   'PurchaseDate' => '2014-10-26T04:40:40Z',
                   'AmazonOrderId' => '333-9999999-99999999',
@@ -90,6 +93,7 @@ my $orderline_data = [
 
 my $order = Amazon::MWS::XML::Order->new(order => $order_data,
                                          orderline => $orderline_data);
+ok $order->is_prime;
 
 is($order->subtotal, "119.80");
 my @items = $order->items;
@@ -106,6 +110,7 @@ my $get_orderline = sub {
 
 $order = Amazon::MWS::XML::Order->new(order => $order_data,
                                       retrieve_orderline_sub => $get_orderline);
+ok $order->is_prime;
 
 my $amazon_order_number = $order->amazon_order_number;
 


### PR DESCRIPTION
The fields are too many and depends on the XSD anyway.