### PR TITLE
Add optional amazon_mws_products.data_timestamp column

### DIFF
--- a/examples/amazon_mws.sql
+++ b/examples/amazon_mws.sql
@@ -47,6 +47,7 @@ CREATE TABLE amazon_mws_products (
        listed_date DATETIME,
        -- our update
        last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+       data_timestamp DATETIME,
        PRIMARY KEY (sku, shop_id)
 );
 

--- a/lib/Amazon/MWS/Uploader.pm
+++ b/lib/Amazon/MWS/Uploader.pm
@@ -2651,7 +2651,7 @@ sub mark_failed_products_as_redo {
                                           }));
 }
 
-=head get_product_data_timestamp($sku)
+=head2 get_product_data_timestamp($sku)
 
 Retrieve the C<amazon_mws_products.data_timestamp> column for the
 given sku.


### PR DESCRIPTION
The value should be passed to the constructor.

If passed, the value will be set when uploading a product.

The caller can later check the age of the uploaded data calling
get_product_data_timestamp($sku)